### PR TITLE
[#9] : 로그인, 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/bookservice/common/exception/ErrorCode.java
+++ b/src/main/java/com/bookservice/common/exception/ErrorCode.java
@@ -7,8 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+	NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "MEMBER_001", "찾을 수 없는 이메일입니다."),
 	ALREADY_EXIST_EMAIL(HttpStatus.CONFLICT, "MEMBER_002", "이미 존재하는 이메일입니다."),
 	ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "MEMBER_003", "이미 존재하는 닉네임입니다."),
+	NOT_VALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER_004", "비밀번호를 다시 확인해주세요."),
 
 	NOT_FOUND_BOOK(HttpStatus.NOT_FOUND, "BOOK_001", "찾을 수 없는 책입니다."),
 

--- a/src/main/java/com/bookservice/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/bookservice/common/security/config/SecurityConfig.java
@@ -20,7 +20,11 @@ public class SecurityConfig{
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
-			.csrf(AbstractHttpConfigurer::disable);
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests((auth) -> auth
+				.requestMatchers("/api/auth/**").permitAll()
+				.anyRequest().authenticated()
+			);
 		return http.build();
 	}
 }

--- a/src/main/java/com/bookservice/member/controller/MemberController.java
+++ b/src/main/java/com/bookservice/member/controller/MemberController.java
@@ -1,15 +1,14 @@
 package com.bookservice.member.controller;
 
 import com.bookservice.common.response.SuccessMessage;
+import com.bookservice.member.dto.request.MemberLoginRequest;
 import com.bookservice.member.dto.request.MemberSignUpRequest;
 import com.bookservice.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,5 +21,17 @@ public class MemberController {
 	public ResponseEntity<SuccessMessage<Void>> signUp(@RequestBody MemberSignUpRequest member) {
 		memberService.signUp(member);
 		return new ResponseEntity<>(new SuccessMessage<>("회원가입성공",null), HttpStatus.CREATED);
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<SuccessMessage<Void>> login(@RequestBody MemberLoginRequest member, HttpServletRequest reuqest) {
+		memberService.login(member);
+		return new ResponseEntity<>(new SuccessMessage<>("로그인성공",null), HttpStatus.OK);
+	}
+
+	@GetMapping("/logout")
+	public ResponseEntity<SuccessMessage<Void>> logout() {
+		memberService.logout();
+		return new ResponseEntity<>(new SuccessMessage<>("로그아웃성공",null), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/bookservice/member/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/bookservice/member/dto/request/MemberLoginRequest.java
@@ -1,0 +1,11 @@
+package com.bookservice.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberLoginRequest {
+	private String email;
+	private String password;
+}

--- a/src/main/java/com/bookservice/member/repository/MemberRepository.java
+++ b/src/main/java/com/bookservice/member/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package com.bookservice.member.repository;
 import com.bookservice.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/bookservice/member/service/LoginService.java
+++ b/src/main/java/com/bookservice/member/service/LoginService.java
@@ -1,0 +1,6 @@
+package com.bookservice.member.service;
+
+public interface LoginService {
+	void login(String email);
+	void logout();
+}

--- a/src/main/java/com/bookservice/member/service/MemberService.java
+++ b/src/main/java/com/bookservice/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.bookservice.member.service;
 
+import com.bookservice.common.exception.BookException;
+import com.bookservice.common.exception.ErrorCode;
+import com.bookservice.member.dto.request.MemberLoginRequest;
 import com.bookservice.member.dto.request.MemberSignUpRequest;
 import com.bookservice.member.entity.Member;
 import com.bookservice.member.repository.MemberRepository;
@@ -9,12 +12,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import static com.bookservice.common.exception.ErrorCode.NOT_FOUND_EMAIL;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final LoginService loginService;
 
 	@Validated
 	@Transactional
@@ -22,5 +28,21 @@ public class MemberService {
 		String encodePassword = passwordEncoder.encode(request.getPassword());
 		Member member = request.toMember(encodePassword);
 		memberRepository.save(member);
+	}
+
+	public void login(MemberLoginRequest request) {
+		Member member = memberRepository.findByEmail(request.getEmail()).orElseThrow(
+				() -> new BookException(NOT_FOUND_EMAIL));
+
+		if(passwordEncoder.matches(request.getPassword(), member.getPassword())){
+			loginService.login(member.getEmail());
+			return;
+		}
+		throw new BookException(ErrorCode.NOT_VALID_PASSWORD);
+
+	}
+
+	public void logout(){
+		loginService.logout();
 	}
 }

--- a/src/main/java/com/bookservice/member/service/SessionLoginService.java
+++ b/src/main/java/com/bookservice/member/service/SessionLoginService.java
@@ -1,0 +1,42 @@
+package com.bookservice.member.service;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@AllArgsConstructor
+@Service
+public class SessionLoginService implements LoginService{
+
+	private static final String USER_ID = "USER_ID";
+	private final HttpSession session;
+
+	@Override
+	public void login(String email) {
+		session.setAttribute(USER_ID, email);
+
+		setAuthenticationContext(email);
+	}
+
+	private void setAuthenticationContext(String email) {
+		Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(authentication);
+
+		SecurityContextHolder.setContext(context);
+		session.setAttribute("SPRING_SECURITY_CONTEXT", context);
+	}
+
+	@Override
+	public void logout() {
+		SecurityContextHolder.clearContext();
+		session.invalidate();
+	}
+}


### PR DESCRIPTION
# 주요 구현 사항
- `SecurityFilterChain`
    - X-CSRF-Token 발급 로직 생략으로 인해 현재 세션 방식을 사용중이지만 로그인을 CSRF 보호 기능 비활성화
    - 이후 JWT Token을 이용한 로그인으로 수정 예정
- 로그인 시 세션 생성 로직
    - `session.setAttribute(...)`를 수행하여 세션이 생성되거나 갱신되면, 스프링 부트가 응답 헤더를 자동 생성.
    - 서비스에서 `session` 객체를 다루기만 하면, 헤더 처리는 자동으로 됩니다.
- 로그아웃 시 세션 생성 로직
    - 서버에 있는 세션 정보를 지워서 클라이언트가 들고 있는 키를 지우는 것.
    - `session.invalidate(...)`서버 메모리에 있는 해당 사용자의 세션을 삭제합니다.
# Session ID 인증을 채택한 이유
- 애플리케이션 서버가 하나인 단일 서버 환경에서는 Session 기반 로그인이 JWT보다 더 적합하고 유리한 면이 많습니다.

1. 보안성 : 세션이 더 안전하고 통제하기 쉽습니다.
2. 구현의 단순성 : 오버헤드가 적습니다.
3. JWT를 도입하기 위해 커스텀 필터를 생성하고, 직접 설정해야 하는 공수가 많이 듭니다. 

**이러한 특징들때문에 핵심 비즈니스 로직에 집중하기 위해 세션 방식이 훨씬 적합하다고 판단했습니다.**