### PR TITLE
[#12] Redis Session Storage를 이용하여 세션 관리하도록 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,7 @@ dependencies {
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.redisson:redisson-spring-boot-starter:3.35.0'
-	implementation 'org.redisson:redisson:3.20.0'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/bookservice/common/redis/config/RedisConfig.java
+++ b/src/main/java/com/bookservice/common/redis/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.bookservice.common.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+	@Value("${spring.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(){
+		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(redisHost, redisPort);
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
+	}
+}


### PR DESCRIPTION
# 주요 구현 사항
- 다중 서버에서 세션 공유를 위해 `InmemoryDB`로 세션 관리하도록 변경하였습니다.
### Redis를 선택한 이유?
  - **서버들끼리 네트워크 요청**을 해야하는 세션 클러스터링의 단점을  
  극복합니다.
  - **한대의 서버에 트래픽이 몰리면 분산하는 기능**을 통해 스티키 세션의 단점도 극복합니다.
  - 서버를 `Stateless`(무상태)로 유지하여 어떤 서버로 접속해도 
  똑같은 서비스를 받을 수 있기 때문에, 서버를 10대, 100대로 
  늘리기(`Scale-out`)가 매우 쉬워집니다.
### 인메모리 DB의 종류중 Redis를 선택한 이유?
  - `Memcached`는 정적 데이터(HTML)를 사용할 때 적합하고, 
  `Redis`의 데이터 영속화 지원, 복제(`replication`)을 통한 
  가용성을 만족하기 위해서 Redis를 사용했습니다.
### `Lettuce`를 선택한 이유?
  - `Jedis`는 동기식 통신만 지원하고, thread safe 하지 않아 **비동기 처리와 연결 비용 관리를 위해 Lettuce를 사용**했습니다.