### PR TITLE
[#32]주간 베스트 셀러 도서 조회 기능을 Redis 캐싱을 통해 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'naver.webtoon'
@@ -30,51 +29,29 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// JWT
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
-
+	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// DB & Lombok
 	runtimeOnly 'com.mysql:mysql-connector-j'
-
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok:1.18.22'
-
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-}
-
-// Qtype 생성 경로
-def querydslDir = "$buildDir/generated/querydsl"
-clean {
-	delete file(querydslDir)
-}
-querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
-}
-sourceSets {
-	main.java.srcDir querydslDir
-}
-compileQuerydsl{
-	options.annotationProcessorPath = configurations.querydsl
-}
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-	querydsl.extendsFrom compileClasspath
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bookservice/book/controller/BookController.java
+++ b/src/main/java/com/bookservice/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package com.bookservice.book.controller;
 
 import com.bookservice.book.dto.request.BookRegisterRequest;
+import com.bookservice.book.dto.request.BookSearchRequest;
 import com.bookservice.book.dto.request.BookUpdateRequest;
 import com.bookservice.book.dto.response.BookResponse;
 import com.bookservice.book.service.BookService;
@@ -11,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/book")
@@ -18,7 +21,7 @@ public class BookController {
 
 	private final BookService bookService;
 
-	@PostMapping
+	@PostMapping("/book")
 	public ResponseEntity<SuccessMessage<Void>> registerBook(@Valid @RequestBody BookRegisterRequest request){
 		bookService.registerBook(request);
 		return new ResponseEntity<>(new SuccessMessage<>("책등록성공", null), HttpStatus.CREATED);
@@ -40,5 +43,21 @@ public class BookController {
 	public ResponseEntity<SuccessMessage<BookResponse>> getBookInfo(@PathVariable Long bookId){
 		BookResponse bookInfo = bookService.getBookInfo(bookId);
 		return new ResponseEntity<>(new SuccessMessage<>("책조회성공", bookInfo), HttpStatus.OK);
+	}
+
+	@GetMapping("/allBooks")
+	public ResponseEntity<SuccessMessage<List<BookResponse>>> getBookListResponse(
+			@RequestBody BookSearchRequest searchRequest,
+			@RequestParam(defaultValue = "1") int pageNo,
+			@RequestParam(defaultValue = "10") int pageSize){
+		List<BookResponse> bookList = bookService.getBookListResponse(searchRequest, pageNo, pageSize);
+		return new ResponseEntity<>(new SuccessMessage<>("모든책조회성공", bookList), HttpStatus.OK);
+	}
+
+	@GetMapping("/bestSellers")
+	public ResponseEntity<SuccessMessage<List<BookResponse>>> getBestSellersResponse(@RequestParam(defaultValue = "1") int pageNo,
+																				   @RequestParam(defaultValue = "10") int pageSize){
+		List<BookResponse> bookList = bookService.getBestSellersResponse(pageNo, pageSize);
+		return new ResponseEntity<>(new SuccessMessage<>("실시간베스트셀러조회성공", bookList), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/bookservice/book/dto/request/BookSearchRequest.java
+++ b/src/main/java/com/bookservice/book/dto/request/BookSearchRequest.java
@@ -1,0 +1,12 @@
+package com.bookservice.book.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BookSearchRequest {
+	private final String searchTitle;
+	private final Integer minPrice;
+	private final Integer maxPrice;
+}

--- a/src/main/java/com/bookservice/book/dto/response/BookResponse.java
+++ b/src/main/java/com/bookservice/book/dto/response/BookResponse.java
@@ -1,28 +1,30 @@
 package com.bookservice.book.dto.response;
 
 import com.bookservice.book.entity.Book;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class BookResponse {
-	private final Long bookId;
-	private final String title;
-	private final String thumbnail;
-	private final String description;
-	private final String releaseDate;
-	private final Integer viewCount;
-	private final Integer interestedCount;
-	private final Integer averageRating;
-	private final Integer reviewCount;
-	private final Boolean isFree;
-	private final Integer price;
-	private final String author;
-	private final List<String> bookHashTags;
+	private Long bookId;
+	private String title;
+	private String thumbnail;
+	private String description;
+	private String releaseDate;
+	private Integer viewCount;
+	private Integer interestedCount;
+	private Integer averageRating;
+	private Integer reviewCount;
+	private Boolean isFree;
+	private Integer price;
+	private String author;
+	private List<String> bookHashTags;
 
 	public static BookResponse toBook(Book book) {
 		return new BookResponse(
@@ -42,5 +44,23 @@ public class BookResponse {
 						.map(bookHashTag -> bookHashTag.getHashTag().getName())
 						.collect(Collectors.toList())
 		);
+	}
+
+	@Builder
+	@QueryProjection
+	public BookResponse(Long bookId, String title, String thumbnail, String description, String releaseDate, Integer viewCount, Integer interestedCount, Integer averageRating, Integer reviewCount, Boolean isFree, Integer price, String author, List<String> bookHashTags) {
+		this.bookId = bookId;
+		this.title = title;
+		this.thumbnail = thumbnail;
+		this.description = description;
+		this.releaseDate = releaseDate;
+		this.viewCount = viewCount;
+		this.interestedCount = interestedCount;
+		this.averageRating = averageRating;
+		this.reviewCount = reviewCount;
+		this.isFree = isFree;
+		this.price = price;
+		this.author = author;
+		this.bookHashTags = bookHashTags;
 	}
 }

--- a/src/main/java/com/bookservice/book/repository/BookRepository.java
+++ b/src/main/java/com/bookservice/book/repository/BookRepository.java
@@ -2,8 +2,6 @@ package com.bookservice.book.repository;
 
 import com.bookservice.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface BookRepository extends JpaRepository<Book, Long>, BookRepositoryCustom {
 }

--- a/src/main/java/com/bookservice/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/com/bookservice/book/repository/BookRepositoryCustom.java
@@ -1,10 +1,16 @@
 package com.bookservice.book.repository;
 
+import com.bookservice.book.dto.request.BookSearchRequest;
+import com.bookservice.book.dto.response.BookResponse;
 import com.bookservice.book.entity.Book;
+import org.springframework.data.domain.PageRequest;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookRepositoryCustom {
 	Optional<Book> findByIdWithHashTags(Long id);
 	void updateViews(Long bookId);
+	List<BookResponse> findBookListResponse(BookSearchRequest searchRequest, PageRequest pageable);
+	List<BookResponse> getBestSellersResponse(PageRequest pageable);
 }

--- a/src/main/java/com/bookservice/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/bookservice/book/repository/BookRepositoryCustomImpl.java
@@ -1,31 +1,40 @@
 package com.bookservice.book.repository;
 
+import com.bookservice.book.dto.request.BookSearchRequest;
+import com.bookservice.book.dto.response.BookResponse;
+import com.bookservice.book.dto.response.QBookResponse;
 import com.bookservice.book.entity.Book;
-import com.bookservice.book.entity.QBook;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static com.bookservice.author.entity.QAuthor.author;
 import static com.bookservice.book.entity.QBook.book;
 import static com.bookservice.book.entity.QBookHashTag.bookHashTag;
 import static com.bookservice.hashtag.entity.QHashTag.hashTag;
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
 
 @Repository
 @RequiredArgsConstructor
-public class BookRepositoryCustomImpl implements BookRepositoryCustom{
+public class BookRepositoryCustomImpl implements BookRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 
 	@Override
 	public Optional<Book> findByIdWithHashTags(Long id) {
 		Book result = queryFactory
-							 .selectFrom(QBook.book)
-							 .join(QBook.book.bookHashTags, bookHashTag).fetchJoin()
-							 .join(bookHashTag.hashTag, hashTag).fetchJoin()
-							 .where(QBook.book.id.eq(id))
-							 .fetchOne();
+							  .selectFrom(book)
+							  .join(book.bookHashTags, bookHashTag).fetchJoin()
+							  .join(bookHashTag.hashTag, hashTag).fetchJoin()
+							  .where(book.id.eq(id))
+							  .fetchOne();
 
 		return Optional.ofNullable(result);
 	}
@@ -36,5 +45,110 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom{
 				.set(book.viewCount, book.viewCount.add(1))
 				.where(book.id.eq(bookId))
 				.execute();
+	}
+
+	@Override
+	public List<BookResponse> findBookListResponse(BookSearchRequest searchRequest, PageRequest pageable) {
+		List<Long> bookIds = queryFactory
+									 .select(book.id)
+									 .from(book)
+									 .orderBy(book.id.desc())
+									 .offset(pageable.getOffset())
+									 .limit(pageable.getPageSize())
+									 .fetch();
+
+		return queryFactory
+					   .from(book)
+					   .join(book.author, author)
+					   .leftJoin(book.bookHashTags, bookHashTag)
+					   .leftJoin(bookHashTag.hashTag, hashTag)
+					   .where(book.id.in(bookIds))
+					   .orderBy(book.id.desc())
+					   .transform(
+							   groupBy(book.id).list(
+									   new QBookResponse(
+											   book.id,
+											   book.title,
+											   book.thumbnail,
+											   book.description,
+											   book.releaseDate,
+											   book.viewCount,
+											   book.interestedCount,
+											   book.averageRating,
+											   book.reviewCount,
+											   book.isFree,
+											   book.price,
+											   book.author.name,
+											   list(hashTag.name)
+									   )
+							   )
+					   );
+	}
+
+	@Override
+	public List<BookResponse> getBestSellersResponse(PageRequest pageable) {
+		LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
+
+		List<Long> bookIds = queryFactory
+									 .select(book.id)
+									 .from(book)
+									 .where(
+											 book.releaseDate.goe(String.valueOf(oneWeekAgo))
+									 )
+									 .orderBy(
+											 book.viewCount.desc(),
+											 book.interestedCount.desc(),
+											 book.id.desc()
+									 )
+									 .offset(pageable.getOffset())
+									 .limit(pageable.getPageSize())
+									 .fetch();
+
+		return queryFactory
+					   .from(book)
+					   .join(book.author, author)
+					   .leftJoin(book.bookHashTags, bookHashTag)
+					   .leftJoin(bookHashTag.hashTag, hashTag)
+					   .where(book.id.in(bookIds))
+					   .orderBy(
+							   // 조회수 > 관심등록수 > 최신등록 순
+							   book.viewCount.desc(),
+							   book.interestedCount.desc(),
+							   book.id.desc()
+					   )
+					   .transform(
+							   groupBy(book.id).list(
+									   new QBookResponse(
+											   book.id,
+											   book.title,
+											   book.thumbnail,
+											   book.description,
+											   book.releaseDate,
+											   book.viewCount,
+											   book.interestedCount,
+											   book.averageRating,
+											   book.reviewCount,
+											   book.isFree,
+											   book.price,
+											   book.author.name,
+											   list(hashTag.name)
+									   )
+							   )
+					   );
+	}
+
+	private BooleanExpression eqTitle(String searchTitle) {
+		return searchTitle != null ? book.title.eq(searchTitle) : null;
+	}
+
+	private BooleanExpression betweenPrice(Integer minPrice, Integer maxPrice) {
+		if (minPrice == null && maxPrice == null) {
+			return null;
+		} else if (minPrice == null) {
+			return book.price.loe(maxPrice);
+		} else if (maxPrice == null) {
+			return book.price.goe(minPrice);
+		}
+		return book.price.between(minPrice, maxPrice);
 	}
 }

--- a/src/main/java/com/bookservice/book/service/BookService.java
+++ b/src/main/java/com/bookservice/book/service/BookService.java
@@ -3,6 +3,7 @@ package com.bookservice.book.service;
 import com.bookservice.author.entity.Author;
 import com.bookservice.author.repository.AuthorRepository;
 import com.bookservice.book.dto.request.BookRegisterRequest;
+import com.bookservice.book.dto.request.BookSearchRequest;
 import com.bookservice.book.dto.request.BookUpdateRequest;
 import com.bookservice.book.dto.response.BookResponse;
 import com.bookservice.book.entity.Book;
@@ -11,6 +12,9 @@ import com.bookservice.common.exception.BookException;
 import com.bookservice.hashtag.entity.HashTag;
 import com.bookservice.hashtag.repository.HashTagRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +30,10 @@ public class BookService {
 	private final HashTagRepository hashTagRepository;
 
 	@Transactional
+	@CacheEvict(
+			value = "weeklyBestSellers",
+			key = "T(java.time.LocalDate).now().minusDays(7) + ' ~ ' + T(java.time.LocalDate).now() + ':page:' + #pageNo + ':size:' + #pageSize"
+	)
 	public void registerBook(BookRegisterRequest request) {
 		Author author = authorRepository.findByName(request.getAuthor()).orElseThrow(
 				() -> new BookException(NOT_FOUND_AUTHOR));
@@ -39,6 +47,10 @@ public class BookService {
 	}
 
 	@Transactional
+	@CacheEvict(
+			value = "weeklyBestSellers",
+			key = "T(java.time.LocalDate).now().minusDays(7) + ' ~ ' + T(java.time.LocalDate).now() + ':page:' + #pageNo + ':size:' + #pageSize"
+	)
 	public void updateBook(Long bookId, BookUpdateRequest request) {
 		Book book = bookRepository.findById(bookId).orElseThrow(
 				() -> new BookException(NOT_FOUND_BOOK));
@@ -69,15 +81,37 @@ public class BookService {
 	}
 
 	@Transactional
+	@CacheEvict(
+			value = "weeklyBestSellers",
+			key = "T(java.time.LocalDate).now().minusDays(7) + ' ~ ' + T(java.time.LocalDate).now() + ':page:' + #pageNo + ':size:' + #pageSize"
+	)
 	public void deleteBook(Long bookId) {
 		bookRepository.deleteById(bookId);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public BookResponse getBookInfo(Long bookId) {
 		bookRepository.updateViews(bookId);
 		return bookRepository.findByIdWithHashTags(bookId)
 					.map(BookResponse::toBook)
 					.orElseThrow(() -> new BookException(NOT_FOUND_BOOK));
+	}
+
+	@Transactional(readOnly = true)
+	public List<BookResponse> getBookListResponse(BookSearchRequest searchRequest, Integer pageNo, Integer pageSize) {
+		//db에서는 0이 1이다.
+		PageRequest pageable = PageRequest.of(pageNo - 1, pageSize);
+		return bookRepository.findBookListResponse(searchRequest, pageable);
+	}
+
+	@Transactional(readOnly = true)
+	@Cacheable(
+			value = "weeklyBestSellers",
+			key = "T(java.time.LocalDate).now().minusDays(7) + ' ~ ' + T(java.time.LocalDate).now() + ':page:' + #pageNo + ':size:' + #pageSize",
+			cacheManager = "cacheManager"
+	)
+	public List<BookResponse> getBestSellersResponse(int pageNo, int pageSize) {
+		PageRequest pageable = PageRequest.of(pageNo - 1, pageSize);
+		return bookRepository.getBestSellersResponse(pageable);
 	}
 }

--- a/src/main/java/com/bookservice/common/querydsl/config/QueryDslConfig.java
+++ b/src/main/java/com/bookservice/common/querydsl/config/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package com.bookservice.common.querydsl.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -14,6 +15,6 @@ public class QueryDslConfig {
 
 	@Bean
 	public JPAQueryFactory jpaQueryFactory(){
-		return new JPAQueryFactory(entityManager);
+		return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
 	}
 }

--- a/src/main/java/com/bookservice/common/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/bookservice/common/redis/config/RedisCacheConfig.java
@@ -1,0 +1,48 @@
+package com.bookservice.common.redis.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory){
+		RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+														.disableCachingNullValues()
+														//Redis에 Key를 저장할 때 String으로 직렬화해서 저장
+														.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+														//Redis에 Value를 저장할 때 Json으로 직렬화해서 저장
+														.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(createObjectMapper())))
+														.entryTtl(Duration.ofDays(1L));
+
+		return RedisCacheManager
+					   .RedisCacheManagerBuilder
+					   .fromConnectionFactory(redisConnectionFactory)
+					   .cacheDefaults(configuration)
+					   .build();
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		objectMapper.activateDefaultTyping(
+				BasicPolymorphicTypeValidator.builder()
+						.allowIfBaseType(Object.class)
+						.build(),
+				ObjectMapper.DefaultTyping.NON_FINAL
+		);
+		return objectMapper;
+	}
+}


### PR DESCRIPTION
# 작업배경
자주 변경되지 않고 자주 조회되는 베스트셀러 도서 조회 API가 호출될때 마다 불필요하게 DB에 접근하는 현상 

# 구현사항
1. QueryDSL 도입 및 동적 쿼리 구현
- 도서 조회 API, 검색 기능 도입
  - 조회 Reqeust DTO를 추가하여 제목 검색, 가격 범위 필터링을 동적으로 처리하도록 구현
- N+1 문제 해결:
  - `transform`과 `groupBy`를 사용하여, 1:N 관계인 도서(`Book`)와 해시태그(`HashTag`)를 한 번의 쿼리로 조회하고 메모리에서 그룹화하여 성능을 최적화
- DTO 프로젝션 적용 :
  - `BookResponse`에 `@QueryProjection`을 적용하여 QType을 생성, 컴파일 시점에 타입 안정성을 보장하며 조회하도록 변경

2. Redis Caching 적용
- 주간 베스트셀러 조회 캐싱:
  - getBestSellersResponse 메서드에서 @Cacheable을 적용
  - Caching Key 계획 :
    - Value : `weeklyBestSellers`
    - Key : `오늘 날짜 기준 1주일 전 ~ 오늘` + `페이지 정보`
    - TTL : `1일`
    - **데이터 수정없이 캐싱 효과를 최대한 받기 위해 최대한 긴 시간인 하루동안 데이터의 유효 기간 설정**
- 캐시 무효화:
  - 도서 등록, 수정, 삭제 발생 시 `@CacheEvict`를 통해 관련 베스트셀러 캐시를 갱신하도록 처리

# 기술적 의사결정
- QueryDSL transform 사용 이유 : JPA 조회 시 컬렉쳔 패치 조인을 사용하면 페이징 불가(OOM 위험)이 있어, ID 기반으로 페이징을 먼저 수행하고 이후 transform을 통해 데이터를 조합하는 방식으로 구현
- Redis Key 설계 : 베스트셀러 기준이 '최근 1주일'이므로, 날짜가 바뀌면 자동으로 키가 변경되어 새로운 데이터를 조회되도록 SpEL을 활용해 LocalDate를 Key에 포함

# 결과
평균 조회 결과 : 200백만건 기준, 260ms -> 20ms으로 약 92% 개선
